### PR TITLE
Use girder_geospatial:2.x-mainenance branch to match girder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *~
 *.egg-info
 data
+
+build
+dist

--- a/Dockerfile.girder
+++ b/Dockerfile.girder
@@ -18,7 +18,7 @@ RUN pip install \
     palettable \
     pyproj
 
-RUN git clone https://github.com/OpenGeoscience/girder_geospatial.git /geometa && \
+RUN git clone --branch 2.x-maintenance https://github.com/OpenGeoscience/girder_geospatial.git /geometa && \
     cd /geometa && pip install . && pip install types/vector types/raster types/grid && \
     girder-install plugin . -s
 


### PR DESCRIPTION
Need to clone the 2.x-maintenance branch from girder_geospatial, to match the girder version